### PR TITLE
Add efficient LPIPS computation

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Note: we support both gaussian original kernel and DPTR kernel.
 1. Download the lego data and put it in your folder:
 
 ```bash
-wget http://cseweb.ucsd.edu/\~viscomp/projects/LF/papers/ECCV20/nerf/nerf_example_data.zip
+wget http://cseweb.ucsd.edu/~viscomp/projects/LF/papers/ECCV20/nerf/nerf_example_data.zip
 ```
 
 2. Run the following command to train the model (...data path in the config file...):

--- a/pointrix/exporter/novel_view.py
+++ b/pointrix/exporter/novel_view.py
@@ -12,7 +12,8 @@ from operator import methodcaller
 
 from pointrix.utils.losses import l1_loss
 from pointrix.utils.system import mkdir_p
-from pointrix.utils.gaussian_points.gaussian_utils import psnr
+# from pointrix.utils.gaussian_points.gaussian_utils import psnr
+from pointrix.model.loss import psnr, ssim, LPIPS
 from pointrix.utils.visuaize import visualize_depth, visualize_rgb
 
 
@@ -34,6 +35,9 @@ def test_view_render(model, renderer, datapipeline, output_path, device='cuda'):
     """
     l1_test = 0.0
     psnr_test = 0.0
+    ssim_test = 0.0
+    lpips_test = 0.0
+    lpips_func = LPIPS()
     val_dataset = datapipeline.validation_dataset
     val_dataset_size = len(val_dataset)
     progress_bar = tqdm(
@@ -64,11 +68,15 @@ def test_view_render(model, renderer, datapipeline, output_path, device='cuda'):
 
         l1_test += l1_loss(image, gt_image).mean().double()
         psnr_test += psnr(image, gt_image).mean().double()
+        ssim_test += ssim(image, gt_image).mean().double()
+        lpips_test += lpips_func(image, gt_image).mean().double()
         progress_bar.update(1)
     progress_bar.close()
     l1_test /= val_dataset_size
     psnr_test /= val_dataset_size
-    print(f"Test results: L1 {l1_test:.5f} PSNR {psnr_test:.5f}")
+    ssim_test /= val_dataset_size
+    lpips_test /= val_dataset_size
+    print(f"Test results: L1 {l1_test:.5f} PSNR {psnr_test:.5f} SSIM {ssim_test:.5f} LPIPS (VGG) {lpips_test:.5f}")
 
 
 def novel_view_render(model, renderer, datapipeline, output_path, novel_view_list=["Dolly", "Zoom", "Spiral"], device='cuda'):

--- a/pointrix/hook/log_hook.py
+++ b/pointrix/hook/log_hook.py
@@ -18,7 +18,7 @@ class LogHook(Hook):
         self.bar_info = {}
         
         # self.losses_test = {"L1_loss": 0., "psnr": 0., "ssims": 0., "lpips": 0.}
-        self.losses_test = {"L1_loss": 0., "psnr": 0., "ssims": 0.}
+        self.losses_test = {"L1_loss": 0., "psnr": 0., "ssims": 0., "lpips": 0.}
 
     def before_run(self, trainner) -> None:
         """

--- a/pointrix/model/base_model.py
+++ b/pointrix/model/base_model.py
@@ -181,7 +181,7 @@ class BaseModel(BaseModule):
         if num_pts != len(self.point_cloud):
             self.point_cloud.re_init(num_pts)
 
-        return super().load_state_dict(state_dict, strict, assign)
+        return super().load_state_dict(state_dict, strict)
 
     def get_state_dict(self):
         additional_info = {'num_pts': len(self.point_cloud)}

--- a/pointrix/model/loss.py
+++ b/pointrix/model/loss.py
@@ -4,6 +4,7 @@ from jaxtyping import Float
 import torch.nn.functional as F
 from torch.autograd import Variable
 from math import exp
+import lpips
 
 def psnr(img1:Float[Tensor, "H W C"], img2:Float[Tensor, "H W C"]):
     """
@@ -110,4 +111,16 @@ def _ssim(img1, img2, window, window_size, channel, size_average=True):
         return ssim_map.mean()
     else:
         return ssim_map.mean(1).mean(1).mean(1)
+    
+class LPIPS(object):
+    def __init__(self, device='cuda', net='vgg'):
+        if net == 'vgg':
+            self.model = lpips.LPIPS(net='vgg').to(device)
+        elif net == 'alex':
+            self.model = lpips.LPIPS(net='alex').to(device)
+        else:
+            assert False, "Could not recognize network type for LPIPS!"
+
+    def __call__(self, img1, img2):
+        return self.model(img1, img2)
     


### PR DESCRIPTION
I implemented an efficient LPIPS computation aligned with vanilla 3D-GS.

The time cost does not significantly increase (21s to 22s on Mip-360 bonsai, 3090). 

![image](https://github.com/pointrix-project/pointrix/assets/63096187/c7d621ae-4c75-46de-8e4b-94ff8b86bf33)

I also add ssim and lpips (vgg) in the final evaluation, which vanilla 3D-GS outputs in `metrics.py`.
![image](https://github.com/pointrix-project/pointrix/assets/63096187/144c5655-6144-4016-85b7-bff87c32964a)
